### PR TITLE
Use devDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "test"
   }, 
   "version": "0.0.0", 
-  "dependencies": {
+  "devDependencies": {
     "mocha": "~1.12.0", 
     "expect.js": "~0.2.0"
   }, 


### PR DESCRIPTION
There's no apparent reason why these should be required to use the library rather than while developing the library so these should be devDependencies not regular dependencies.